### PR TITLE
No alloc assertions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Also implement a musical beat scheduling time primitive along the ideas of BillyDM expressed in that same blog post.
 - Barebones scheduling of events in musical time.
 - Streamlined examples to decrease maintenance time.
+- Enable assertions for no allocation on the audio thread when compiling in debug mode.
 
 ## 0.3.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ cpal = {version = "0.14.0", optional = true }
 # Only for non real time use
 crossbeam-channel = "0.5.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
+assert_no_alloc = "1.1.2"
 
 # For concurrency testing
 [target.'cfg(loom)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ homepage = "https://github.com/ErikNatanael/knyst"
 all-features = true
 
 [features]
-serde-derive = ["serde"]
+serde-derive = ["dep:serde"]
+debug-warn-on-alloc = ["assert_no_alloc/warn_debug"]
 
 [dependencies]
 slotmap = "1.0"
@@ -38,7 +39,7 @@ cpal = {version = "0.14.0", optional = true }
 # Only for non real time use
 crossbeam-channel = "0.5.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
-assert_no_alloc = "1.1.2"
+assert_no_alloc = { version = "1.1.2" }
 
 # For concurrency testing
 [target.'cfg(loom)'.dependencies]

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -352,6 +352,9 @@ fn insert_reverb(
 }
 
 /// Create a Gen containing a fundsp graph
+///
+/// Note: This currently allocates on the audio thread, the creator of fundsp is
+/// working on a solution
 fn fundsp_reverb_gen(sample_rate: f64, mix: f32) -> ClosureGen {
     use fundsp::audiounit::AudioUnit32;
     let mut fundsp_graph = {

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -356,11 +356,7 @@ fn fundsp_reverb_gen(sample_rate: f64, mix: f32) -> ClosureGen {
     use fundsp::audiounit::AudioUnit32;
     let mut fundsp_graph = {
         use fundsp::hacker32::*;
-        //let mut c = c * 0.1;
-        // let mut c = multipass() & mix * reverb_stereo(10.0, 5.0);
-        // let mut c = pass() & feedback(delay(1.0) >> lowpass_hz(1000.0, 1.0));
-        // let mut c = zero();
-        let mut c = triangle();
+        let mut c = multipass() & mix * reverb_stereo(10.0, 5.0);
         c.reset(Some(sample_rate));
         c
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,15 @@ use slotmap::{SecondaryMap, SlotMap};
 use std::{collections::HashMap, hash::Hash, sync::atomic::AtomicU64};
 use wavetable::{Wavetable, WavetableKey};
 
+// assert_no_alloc to make sure we are not allocating on the audio thread. The
+// assertion is put in AudioBackend.
+#[allow(unused_imports)]
+use assert_no_alloc::*;
+
+#[cfg(debug_assertions)] // required when disable_release is set (default)
+#[global_allocator]
+static A: AllocDisabler = AllocDisabler;
+
 pub mod audio_backend;
 pub mod buffer;
 pub mod controller;


### PR DESCRIPTION
Enables assertions to make sure no allocations are made on the audio thread in debug mode. In release mode the assertions are removed. The feature `debug-warn-on-alloc` prints a warning instead of panicking. 